### PR TITLE
read trimmed parameters / switch shutter / add TB to log / maintain config file line order / small changes

### DIFF
--- a/config/sort_ini.py
+++ b/config/sort_ini.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+
+import sys
+
+HELP = "usage: sort_ini.py file.ini"
+
+def do_sort(filename, outputname):
+	iniFile = file(filename)
+	lines = iniFile.readlines()
+	iniFile.close()
+	currentSection = ""
+	sections = {}
+	for line in lines:
+		line = line.strip()
+		if line.startswith("[") and line.endswith("]"):
+			currentSection = line[1:-1]
+			sections.update({currentSection: [line,]})
+		else:
+			if len(line) > 0:
+				sections[currentSection].append(line)
+
+	sortedSections = sections.keys()
+	sortedSections.sort()
+
+	f = open(outputname, 'w')
+	for section in sortedSections:
+		for line in sections[section]:
+			f.write(line)
+			f.write("\n")
+		f.write("\n")
+	f.close()
+
+if "--help" in sys.argv:
+	print HELP
+else:
+	if len(sys.argv) == 3:
+		do_sort(sys.argv[1], sys.argv[2])
+	elif len(sys.argv) ==2:
+		do_sort(sys.argv[1], sys.argv[1])
+	else:
+		print "wrong syntax\n"
+		print HELP	

--- a/config/tests/HighRateEfficiency
+++ b/config/tests/HighRateEfficiency
@@ -1,1 +1,0 @@
-HighRateEfficiency

--- a/config/tests/XraySpectrum
+++ b/config/tests/XraySpectrum
@@ -1,1 +1,1 @@
-HRMap
+Xray

--- a/elComandante/el_comandante.py
+++ b/elComandante/el_comandante.py
@@ -547,12 +547,16 @@ class el_comandante:
             self.log.printn()
 
             # Execute tests
+            startTime = time.time()
             self.log << "Executing test %s ..." % test.test_str
             for agente in self.los_agentes:
                 agente.execute_test()
             self.wait_until_finished()
 
             self.log.printn()
+            endTime = time.time()
+            testDuration = divmod(endTime-startTime, 60)
+            self.log << " test took %i seconds (%i min %i sec)" % (endTime-startTime, testDuration[0], testDuration[1])
 
             # Cleanup tests
             self.log << "Cleaning up after test %s ..." % test.test_str

--- a/elComandante/el_comandante.py
+++ b/elComandante/el_comandante.py
@@ -448,11 +448,15 @@ class el_comandante:
         while True:
             try:
                 module_type = self.init.get("ModuleType", "TB" + `tb`)
-                dir = self.config.get("defaultParameters", module_type)
+                try:
+                    dir = self.config.get("defaultParametersTB"+str(tb), module_type)
+                except:
+                    dir = self.config.get("defaultParameters", module_type)
             except:
                 break
             else:
                 dir = self.directories['defaultParameters'] + '/' + dir
+                self.log << "append " + dir + " to dir_list"
                 dir_list.append(dir)
                 tb += 1
         test_chain.parameter_dir = dir_list

--- a/elComandante/el_comandante.py
+++ b/elComandante/el_comandante.py
@@ -13,6 +13,7 @@
 import sys
 sys.path.insert(1, "../")
 from myutils import BetterConfigParser, sClient, printer, testchain, scp, userQueries
+from collections import OrderedDict
 from time import strftime, localtime
 import time
 from shutil import copytree, rmtree
@@ -293,7 +294,7 @@ class el_comandante:
 
     def read_initialization(self, configDir):
         iniFile = configDir+'/elComandante.ini'
-        self.init = BetterConfigParser()
+        self.init = BetterConfigParser(dict_type=OrderedDict)
         self.init.read(iniFile)
         self.write_initialization(configDir)
 

--- a/elComandante/el_comandante.py
+++ b/elComandante/el_comandante.py
@@ -448,10 +448,7 @@ class el_comandante:
         while True:
             try:
                 module_type = self.init.get("ModuleType", "TB" + `tb`)
-                try:
-                    dir = self.config.get("defaultParametersTB"+str(tb), module_type)
-                except:
-                    dir = self.config.get("defaultParameters", module_type)
+                dir = self.config.get("defaultParameters", module_type)
             except:
                 break
             else:

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -38,10 +38,7 @@ class psi_agente(el_agente.el_agente):
         for tb, module in init.items('Modules'):
             if init.getboolean('TestboardUse',tb):
                 self.Testboards.append(Testboarddefinition(int(tb[2]),module,self.conf.get('TestboardAddress',tb),init.get('ModuleType',tb)))
-                try:
-                    defaultParameterDirectory = self.conf.get('defaultParametersTB'+str(self.Testboards[-1].slot),self.Testboards[-1].type)
-                except:
-                    defaultParameterDirectory = self.conf.get('defaultParameters',self.Testboards[-1].type)
+                defaultParameterDirectory = self.conf.get('defaultParameters',self.Testboards[-1].type)
                 self.Testboards[-1].defparamdir=self.Directories['defaultParameters']+'/'+ defaultParameterDirectory
                 self.log << '\t- Testboard %s at address %s with Module %s reading configuration from %s '%(self.Testboards[-1].slot,self.Testboards[-1].address,self.Testboards[-1].module, defaultParameterDirectory)
         self.numTestboards = len(init.items('Modules'))

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -58,7 +58,7 @@ class psi_agente(el_agente.el_agente):
         self.timestamp = timestamp
         if not self.active:
             return True
-        command = "xterm -T 'PSI46master' +sb -geometry 120x20+0+300 -fs 10 -fa 'Mono' -e "
+        command = "xterm -T 'PSI46master' +sb -sl 5000 -geometry 120x50+660+32 -fs 10 -fa 'Mono' -e "
         command += "python ../psiClient/psi46master.py "
         command += "-dir %s "%(self.Directories['logDir'])
         command += "-num %s"%self.numTestboards
@@ -329,7 +329,7 @@ class psi_agente(el_agente.el_agente):
             self.sclient.send('/watchDog',':TB%s:TESTDIR! %s\n'%(Testboard.slot,Testboard.testdir))
             copytree(self.test.parent.parameter_dir[Testboard.slot], Testboard.testdir)
             if Testboard.DTB:    
-                self.log.warning("if Testboard.DTB is fulfilled") 
+                #self.log.warning("if Testboard.DTB is fulfilled") 
                 print self.test.parent.parameter_dir[Testboard.slot]
                 directories = [self.test.parent.parameter_dir[Testboard.slot]+d for d in os.listdir(self.test.parent.parameter_dir[Testboard.slot]) if os.path.isdir(self.test.parent.parameter_dir[Testboard.slot]+d)] 
                 if len(directories) > 0:

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -38,8 +38,12 @@ class psi_agente(el_agente.el_agente):
         for tb, module in init.items('Modules'):
             if init.getboolean('TestboardUse',tb):
                 self.Testboards.append(Testboarddefinition(int(tb[2]),module,self.conf.get('TestboardAddress',tb),init.get('ModuleType',tb)))
-                self.Testboards[-1].defparamdir=self.Directories['defaultParameters']+'/'+self.conf.get('defaultParameters',self.Testboards[-1].type)
-                self.log << '\t- Testboard %s at address %s with Module %s'%(self.Testboards[-1].slot,self.Testboards[-1].address,self.Testboards[-1].module)
+                try:
+                    defaultParameterDirectory = self.conf.get('defaultParametersTB'+str(self.Testboards[-1].slot),self.Testboards[-1].type)
+                except:
+                    defaultParameterDirectory = self.conf.get('defaultParameters',self.Testboards[-1].type)
+                self.Testboards[-1].defparamdir=self.Directories['defaultParameters']+'/'+ defaultParameterDirectory
+                self.log << '\t- Testboard %s at address %s with Module %s reading configuration from %s '%(self.Testboards[-1].slot,self.Testboards[-1].address,self.Testboards[-1].module, defaultParameterDirectory)
         self.numTestboards = len(init.items('Modules'))
     def check_client_running(self):
         if not self.active:

--- a/myutils/tbmaster.py
+++ b/myutils/tbmaster.py
@@ -33,6 +33,21 @@ class TBmaster(object):
         self.DoTest= False
         self.ClosePSI= False
         self.Abort = False
+        self.trimVcal = 40 #default
+        self.init = BetterConfigParser()
+        self.init.read("../config/elComandante.ini")
+        try:
+            testParameters = self.init.get('Test Trim','testParameters')
+            pos1 = testParameters.find("=")
+            if pos1 > 0:
+                testParametersName = testParameters[0:pos1]
+                testParametersValue = testParameters[pos1+1:]
+                self.Logger << "read ->%s<- => ->%s<-"%(testParametersName,testParametersValue)
+                if testParametersName.lower() == "trimvcal":
+                    self.trimVcal = int(testParametersValue)
+                    self.Logger << "using option '-T %s' when calling pxar"%self.trimVcal
+        except:
+            self.Logger << "no trimming test found in ini file"
 
     def _spawn(self,executestr):
         my_env = os.environ
@@ -133,8 +148,7 @@ class TBmaster(object):
         elif self.version == 'pxar':
             # cat test | ../bin/pXar -d whereever
             #executestr = 'cat {testfile} | {psiVersion} -dir {dir}  -r {rootfilename}.root -log {logfilename}.log'.format(testfile = whichTest, psiVersion = self.psiVersion, dir = dir, rootfilename = fname, logfilename = fname)
-            trimVcal = 40 #default
-            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s -T %(trimVcal)i -r %(rootfilename)s.root'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname, 'trimVcal' : trimVcal} 
+            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s -T %(trimVcal)i -r %(rootfilename)s.root'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname, 'trimVcal' : self.trimVcal} 
         else:
             executestr='%s -dir %s -f %s -r %s.root -log %s.log'%(self.psiVersion,dir,whichTest,fname,fname)
         self._spawn(executestr)

--- a/myutils/tbmaster.py
+++ b/myutils/tbmaster.py
@@ -133,7 +133,8 @@ class TBmaster(object):
         elif self.version == 'pxar':
             # cat test | ../bin/pXar -d whereever
             #executestr = 'cat {testfile} | {psiVersion} -dir {dir}  -r {rootfilename}.root -log {logfilename}.log'.format(testfile = whichTest, psiVersion = self.psiVersion, dir = dir, rootfilename = fname, logfilename = fname)
-            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s  -r %(rootfilename)s.root'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname} 
+            trimVcal = 40 #default
+            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s -T %(trimVcal)i -r %(rootfilename)s.root'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname, 'trimVcal' : trimVcal} 
         else:
             executestr='%s -dir %s -f %s -r %s.root -log %s.log'%(self.psiVersion,dir,whichTest,fname,fname)
         self._spawn(executestr)

--- a/myutils/tbmaster.py
+++ b/myutils/tbmaster.py
@@ -42,12 +42,11 @@ class TBmaster(object):
             if pos1 > 0:
                 testParametersName = testParameters[0:pos1]
                 testParametersValue = testParameters[pos1+1:]
-                self.Logger << "read ->%s<- => ->%s<-"%(testParametersName,testParametersValue)
-                if testParametersName.lower() == "trimvcal":
+                if testParametersName.lower() == "vcal":
                     self.trimVcal = int(testParametersValue)
                     self.Logger << "using option '-T %s' when calling pxar"%self.trimVcal
         except:
-            self.Logger << "no trimming test found in ini file"
+            self.Logger << "no [Test Trim] section found in ini file, trying default '-T %s'"%self.trimVcal
 
     def _spawn(self,executestr):
         my_env = os.environ
@@ -148,7 +147,8 @@ class TBmaster(object):
         elif self.version == 'pxar':
             # cat test | ../bin/pXar -d whereever
             #executestr = 'cat {testfile} | {psiVersion} -dir {dir}  -r {rootfilename}.root -log {logfilename}.log'.format(testfile = whichTest, psiVersion = self.psiVersion, dir = dir, rootfilename = fname, logfilename = fname)
-            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s -T %(trimVcal)i -r %(rootfilename)s.root'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname, 'trimVcal' : self.trimVcal} 
+            logIDString = 'TB%s'%self.TB
+            executestr = 'cat %(testfile)s | %(psiVersion)s -d %(dir)s -T %(trimVcal)i -r %(rootfilename)s.root -L %(logIDString)s'%{'testfile' : whichTest, 'psiVersion' : self.psiVersion, 'dir' : dir, 'rootfilename' : fname, 'trimVcal' : self.trimVcal, 'logIDString' : logIDString} 
         else:
             executestr='%s -dir %s -f %s -r %s.root -log %s.log'%(self.psiVersion,dir,whichTest,fname,fname)
         self._spawn(executestr)

--- a/xrayClient/xrayClient.py
+++ b/xrayClient/xrayClient.py
@@ -297,7 +297,7 @@ while client.anzahl_threads > 0 and client.isClosed == False:
 					error = "Invalid target selected."
 					log.warning(error)
 				if shutter != shutter_previous:
-					success = true
+					success = True
 					if shutter_previous != 0 : 
 						success = xray_generator.set_beam_shutter(shutter_previous, 0)
 					success = success and xray_generator.set_beam_shutter(shutter, 1)

--- a/xrayClient/xrayClient.py
+++ b/xrayClient/xrayClient.py
@@ -297,7 +297,9 @@ while client.anzahl_threads > 0 and client.isClosed == False:
 					error = "Invalid target selected."
 					log.warning(error)
 				if shutter != shutter_previous:
-					success = xray_generator.set_beam_shutter(shutter_previous, 0)
+					success = true
+					if shutter_previous != 0 : 
+						success = xray_generator.set_beam_shutter(shutter_previous, 0)
 					success = success and xray_generator.set_beam_shutter(shutter, 1)
 					if not success:
 						error = "Unable to close shutter %d and open shutter %d"%(shutter_previous,shutter)
@@ -368,15 +370,15 @@ while client.anzahl_threads > 0 and client.isClosed == False:
 					client.send(abo, ":ERROR %s\n" % error)
 
 				if on:
-					log << "Turning beam on ..."
+					log << "Turning beam on by opening shutter %d..."%shutter
 				else:
-					log << "Turning beam off ..."
+					log << "Turning beam off by closing shutter %d..."%shutter
 				success = xray_generator.set_beam_shutter(shutter, on)
 				if not success:
 					if on:
-						error = "Unable to turn on the beam."
+						error = "Unable to turn on the beam by opening shutter %d."%shutter
 					else:
-						error = "Unable to turn off the beam."
+						error = "Unable to turn off the beam by opening shutter %d."%shutter
 					log.warning(error)
 					client.send(abo, ":ERROR %s\n" % error)
 				else:

--- a/xrayClient/xrayClient.py
+++ b/xrayClient/xrayClient.py
@@ -285,6 +285,7 @@ while client.anzahl_threads > 0 and client.isClosed == False:
 		if len(commands) == 2 and commands[0].upper() == "SET":
 			if commands[1].upper() == "TARGET":
 				target = message
+				shutter_previous = shutter
 				if target in targets:
 					log << "Moving to target " + target + " ..."
 					motor_stage.move_absolute(targets[target])
@@ -295,6 +296,15 @@ while client.anzahl_threads > 0 and client.isClosed == False:
 				else:
 					error = "Invalid target selected."
 					log.warning(error)
+				if shutter != shutter_previous:
+					success = xray_generator.set_beam_shutter(shutter_previous, 0)
+					success = success and xray_generator.set_beam_shutter(shutter, 1)
+					if not success:
+						error = "Unable to close shutter %d and open shutter %d"%(shutter_previous,shutter)
+						log.warning(error)
+						client.send(abo, ":ERROR %s\n" % error)
+					else:
+						log << "Closed shutter %d and opened shutter %d"%(shutter_previous,shutter)				
 			elif commands[1].upper() == "VOLTAGE":
 				kV = int(message)
 				log << "Setting voltage to " + `kV` + " kV ..."


### PR DESCRIPTION
- shutter automatically switched when moving from HR to fluorescence target test and vice-versa
- trim Vcal value is read from [Test Trim] section of config file and pXar is called with -T .. to support loading already trimmed parameters (from cold box etc.)
- now tells pXar to add a TB information to the log output (needs respective commit in pxar that is not in master yet)
- show duration of single tests
- prevent shuffling of sections and lines of the elComandante.ini file by using ordered dictionaries
- xray client adds information which shutter was opened/closed to log
- added simple script to sort ini files manually
