### PR TITLE
HR environments, hv cycle

### DIFF
--- a/elComandante/environment.py
+++ b/elComandante/environment.py
@@ -95,3 +95,9 @@ class environment():
             self.name = env
         except:
             pass
+
+        # exception for x-ray environments, drop "MHz/cm2" or "MHz" in environment name
+        if "mhz" in env.lower():
+            pos = env.lower().find("mhz")
+            self.name = env[0:pos]
+            self.xray = True

--- a/elComandante/highVoltage_agente.py
+++ b/elComandante/highVoltage_agente.py
@@ -115,8 +115,8 @@ class highVoltage_agente(el_agente.el_agente):
             self.sclient.send(self.subscription,':OUTP ON\n')
             self.doLeakageCurrent()
         else:
-            time.sleep(3)
-            self.sclient.send(self.subscription,':OUTP OFF\n')
+            #time.sleep(3)
+            #self.sclient.send(self.subscription,':OUTP OFF\n')
             time.sleep(1)
             self.sclient.send(self.subscription,':OUTP ON\n')
         self.pending = True

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -117,10 +117,13 @@ class psi_agente(el_agente.el_agente):
             if Testboard.slot != self.activeTestboard:
             #check if it's this TB's turn
                 return
-        if self.test.environment.temperature >=0:
-            tempString = "p%s"%int(self.test.environment.temperature)
+        if self.test.environment.xray and (self.test.environment.xray_target == "" or self.test.environment.xray_target.lower() == "none"):
+            tempString = self.test.environment.name
         else:
-            tempString = "m%s"%(-1*int(self.test.environment.temperature))
+            if self.test.environment.temperature >=0:
+                tempString = "p%s"%int(self.test.environment.temperature)
+            else:
+                tempString = "m%s"%(-1*int(self.test.environment.temperature))
 
         Testboard.testdir = Testboard.parentDir + '/%s_%s_%s/' % (str(Testboard.numerator).zfill(3), self.currenttest, tempString)
         self._setupdir_testboard(Testboard)
@@ -169,7 +172,6 @@ class psi_agente(el_agente.el_agente):
             pass
         else:
             self.log << 'Powercycling Testboards'
-        self.log << 'self.currenttest.lower() = "%s"'%self.currenttest.lower()
         if self.currenttest.lower().startswith('pause'):
             self.log << self.currenttest;
             pos1 = self.currenttest.find('(')

--- a/keithleyClient/keithleyInterface.py
+++ b/keithleyClient/keithleyInterface.py
@@ -18,7 +18,7 @@ class keithleyInterface:
         self.readSleepTime = 0.2
         self.baudrate = 57600
         self.commandEndCharacter = '\r\n'
-        self.removeCharacters = '\r\n\x00\x13\x10'
+        self.removeCharacters = '\r\n\x00\x13\x10\x11'
         self.measurments = deque()
         self.lastVoltage = 0
         self.openSerialPort()


### PR DESCRIPTION
- add environments for high rate tests, eg. "HREfficiency@150MHz/cm2" which is then saved as "000_HREfficiency_150" to be compatible with MoReWeb (before HREfficiency@150 would be  recognized as a temperature)
- remove hv turn off/on in execute_test, but keep the one in preparation, add environment for high rate tests compatible with moreweb
- bug fix of xon/xoff bytes removal
- remove unnecessary old debug output
