### PR TITLE
Changes for running in parallel with pXar and assorted bug fixes

### DIFF
--- a/coolingBox/jumo_coolingBox.py
+++ b/coolingBox/jumo_coolingBox.py
@@ -213,11 +213,11 @@ class jumo_coolingBox(coolingBox):
             sys.stdout.flush()
             return
 
-        if temp - self.setpoint > 0:
+        if temp - self.setpoint > 0 and abs(temp - self.setpoint) > self.deltaT_Max:
             #self.deltaT_Max:
             self.cooling()
             log_message += 'Cooling'
-        elif self.setpoint - temp > self.deltaT_Max:
+        elif self.setpoint - temp > self.deltaT_Max and abs( self.setpoint - temp) > self.deltaT_Max:
             self.heating()
             log_message += 'Heating'
         log_message += '@ {setpoint:+5.1f} degC \t'.format(setpoint=self.setpoint)

--- a/coolingBox/jumo_coolingBox.py
+++ b/coolingBox/jumo_coolingBox.py
@@ -213,11 +213,11 @@ class jumo_coolingBox(coolingBox):
             sys.stdout.flush()
             return
 
-        if temp - self.setpoint > 0 and abs(temp - self.setpoint) > self.deltaT_Max:
+        if temp - self.setpoint > self.deltaT_Max:
             #self.deltaT_Max:
             self.cooling()
             log_message += 'Cooling'
-        elif self.setpoint - temp > self.deltaT_Max and abs( self.setpoint - temp) > self.deltaT_Max:
+        elif self.setpoint - temp > self.deltaT_Max:
             self.heating()
             log_message += 'Heating'
         log_message += '@ {setpoint:+5.1f} degC \t'.format(setpoint=self.setpoint)

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -133,9 +133,9 @@ class psi_agente(el_agente.el_agente):
         self.currenttest='powercycle'
         for Testboard in self.Testboards:
             self._prepare_testboard(Testboard)
-        time.sleep(1)
+        time.sleep(4)
         self.execute_test()
-        time.sleep(1)
+        time.sleep(4)
         self.log <<" %s: do internal power_cycle" %(self.agente_name)
         start_time = time.time()
         while True:
@@ -146,8 +146,8 @@ class psi_agente(el_agente.el_agente):
                 self.log <<" %s: internal power_cycle didn't finished in 120sec, restarting powercycle" % self.agente_name
                 self.execute_test()
                 start_time = time.time()
-            sleep(1)
-        time.sleep(1)
+            sleep(4)
+        time.sleep(4)
         self.cleanup_test()
         self.sclient.clearPackets(self.subscription)
 
@@ -166,6 +166,7 @@ class psi_agente(el_agente.el_agente):
             self.log << 'Powercycling Testboards'
         for Testboard in self.Testboards:
             self._execute_testboard(Testboard)
+            sleep(10)
         sleep(1)
         self.sclient.clearPackets(self.subscription)
         return True    
@@ -231,12 +232,12 @@ class psi_agente(el_agente.el_agente):
     def check_finished(self):
         if not self.active or not self.pending:
             return True
-        sleep(.1)
+        sleep(1)
         for Testboard in self.Testboards:
             if Testboard.busy:
                 self.sclient.send(self.subscription,":STAT:TB%d?\n"%Testboard.slot)
-                sleep(.1)
-        sleep(.1)
+                sleep(1)
+        sleep(1)
         while True:
             packet = self.sclient.getFirstPacket(self.subscription) 
             if packet.isEmpty() or not self.pending:

--- a/psiClient/psi46master.py
+++ b/psiClient/psi46master.py
@@ -170,6 +170,7 @@ def exitProg():
    Logger << 'exit'
    #
    if not reduce(lambda x,y: x or y, [TB.busy for TB in TBmasters]):
+       global End
        End = True
    else:
        for TB in TBmasters:
@@ -210,11 +211,15 @@ def analysePacket(packet):
         if coms[0].startswith('prog') and coms[1].startswith('tb'):
             analyseProg_TB(coms,msg,typ,TBno)
             return
-        elif coms[0].startswith('prog') and coms[1].startswith('exit'):
+        elif coms[0].startswith('exit'):
             exitProg()
             return
         elif coms[0].startswith('stat') and coms[1].startswith('tb') and typ == 'q':
             sendStatsTB(TBno)
+            return
+    elif len(coms)>0:
+        if coms[0].startswith('exit'):
+            exitProg()
             return
     Logger << 'unknown command: %s, %s'%(coms, msg) 
 


### PR DESCRIPTION
@veloxid @xerxes1986
The added delays in psi_agente were found necessary when testing 4 modules in parallel with pXar at FNAL.  Without these delays, we run into communication problems with the DTBs.

Regarding the keithley client, I think most of your comments do not apply to the changes I introduced:
-You also removed the leakage current measurements. This is needed and cannot be removed. Is there any reason why you did that?
-you replaced the read fucntion by a new read function, what is the intention of that?
-You added a self to the staticmethods: this does not really make sense...
-Could you explain the new compliance abort level?

Regarding the remaining comment:
-We should add an option to the KeithleyInterface to define the commandEndCharacters within the config files.

This would be fine as well, but I do not think the addition we made will cause a problem for anyone.

The changes to psi46master were all required to get the psi xterm window to close automatically upon completion of tests.
