### PR TITLE
Config data check

### DIFF
--- a/elComandante/el_comandante.py
+++ b/elComandante/el_comandante.py
@@ -330,6 +330,9 @@ class el_comandante:
             else:
                 break
 
+        if not all(i==len(Testboards) for i in [len(Modules), len(ModuleTypes), len(TBUse)]):
+            print '\x1b[31mERROR: number of TestboardAddress/TestboardUse/Modules/ModuleType rows not equal!\x1b[0m'
+
         # display modules table
         for TBIndex in range(0, len(Testboards)):
             BoxWidth = 54

--- a/elComandante/psi_agente.py
+++ b/elComandante/psi_agente.py
@@ -25,6 +25,8 @@ class psi_agente(el_agente.el_agente):
         self.init = None
         self.active = True
         self.Testboards = []
+        self.LogFileName = ""
+        self.RootFileName = ""
         
     def setup_configuration(self, conf):
         self.conf = conf

--- a/elComandante/watchDog_agente.py
+++ b/elComandante/watchDog_agente.py
@@ -260,10 +260,17 @@ class watchDog_agente(el_agente.el_agente):
             testDict = item[1]
             sortedTests = sorted(testDict.items())
             testNo = max(testDict.keys())
+            errCode = int(self.testOverview[TB][testNo][1])
+            if errCode < 0:
+                sys.stdout.write("\x1b[101m\x1b[97m")
+            elif errCode < 1:
+                sys.stdout.write("\x1b[103m")
+            sys.stdout.flush()
             self.log << "%s  %s-%s\t%s-->%s" % (
                 ' ' * len(self.agente_name), TB, testNo, self.testOverview[TB][testNo][0],
                 self.testOverview[TB][testNo][1])
-
+            if errCode < 1:
+                print "\x1b[0m"
         # self.log << msg
         # if 'waiting' not in self.status()
         # self.log << "%s: Cleaning up %s ..."%(self.agente_name,test)
@@ -305,6 +312,7 @@ class watchDog_agente(el_agente.el_agente):
             msg = "%s   %03d:\t" % (agenteFiller, num)
             testStats = ''
             testName = ''
+            testStatsMin = 1
             for item in sortedOverview:
                 TB = item[0]
                 testDict = item[1]
@@ -315,11 +323,21 @@ class watchDog_agente(el_agente.el_agente):
                     else:
                         testName += '%s/' % status[0]
                     testStat = status[1]
+                    if testStat < testStatsMin:
+                        testStatsMin = testStat
                     testStats += "%2s\t" % testStat
                 else:
                     msg += " \t"
                     testName += '?/'
+            if testStatsMin < 0:
+                sys.stdout.write("\x1b[101m\x1b[97m")
+            elif testStatsMin < 1:
+                sys.stdout.write("\x1b[103m")
+            sys.stdout.flush()
             self.log << '%s%s\t%s' % (msg, testStats, testName)
+            if testStatsMin < 1:
+                print "\x1b[0m"
+
             # sortedTests = sorted(testDict.items())
         # if 'powercycle' in sortedTests[-1][1][0].lower():
         # sortedTest=sortedTests[:-1]


### PR DESCRIPTION
- show dtb/module summary at startup
- add DAC verfification, elComandante.ini, eg.

```
[VerifyDACs]
dacs = vicolor==100,phscale>0,phoffset<=255
```

which shows a warning if the input parameter DACs are not matching. (Useful for x-ray tests which use parameters from cold box)
- check for complete pxar .log files
- check if .root file exists after pxar finishes, but no content/size check
- color output of failed tests to make them easier to spot

resolves #4 
